### PR TITLE
Add ha-mcp server for dad's Home Assistant

### DIFF
--- a/cluster/apps/home-automation/home-assistant-dad/kustomization.yaml
+++ b/cluster/apps/home-automation/home-assistant-dad/kustomization.yaml
@@ -3,4 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./mcp-server.yaml
+  - ./secret.sops.yaml
   # - snapshots.yaml

--- a/cluster/apps/home-automation/home-assistant-dad/mcp-server.yaml
+++ b/cluster/apps/home-automation/home-assistant-dad/mcp-server.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: home-assistant-dad-mcp
+  namespace: home-automation
+  labels:
+    app: home-assistant-dad-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: home-assistant-dad-mcp
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: home-assistant-dad-mcp
+    spec:
+      containers:
+        - name: home-assistant-dad-mcp
+          image: ghcr.io/homeassistant-ai/ha-mcp:7.11.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - fastmcp
+            - run
+            - fastmcp-http.json
+          env:
+            - name: TZ
+              value: Australia/Sydney
+            - name: HOMEASSISTANT_URL
+              value: http://home-assistant-dad:8123
+            - name: HOMEASSISTANT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: home-assistant-dad-mcp
+                  key: TOKEN
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - name: http
+              containerPort: 8086
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: home-assistant-dad-mcp
+  namespace: home-automation
+spec:
+  selector:
+    app: home-assistant-dad-mcp
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8086
+      targetPort: 8086
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: home-assistant-dad-mcp
+  namespace: home-automation
+  annotations:
+    cert-manager.io/cluster-issuer: ca-issuer
+    traefik.ingress.kubernetes.io/router.middlewares: network-system-https-redirectscheme@kubernetescrd
+spec:
+  tls:
+    - hosts:
+        - mcp.homeassistant-dad.${BASE_DOMAIN}
+      secretName: homeassistant-dad-mcp-tls
+  rules:
+    - host: mcp.homeassistant-dad.${BASE_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: home-assistant-dad-mcp
+                port:
+                  number: 8086

--- a/cluster/apps/home-automation/home-assistant-dad/secret.sops.yaml
+++ b/cluster/apps/home-automation/home-assistant-dad/secret.sops.yaml
@@ -1,0 +1,59 @@
+# NOTE: This file is an UNENCRYPTED template.
+# Before committing/deploying, insert a long-lived access token for dad's Home
+# Assistant into stringData.TOKEN and encrypt in place, e.g.:
+#   sops -e -i cluster/apps/home-automation/home-assistant-dad/secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    name: home-assistant-dad-mcp
+    namespace: home-automation
+stringData:
+    TOKEN: ENC[AES256_GCM,data:Ah5PDXfHijneT9srFK9lwtK+3vuwOF8nyeLtWMaGgtX14/+kDFtlRIn3g9i5yrO3C8RD82qM3AcrD5dMxOnfUSl6a3wIthKTz5f7fGPs7IAqD4WDt6vuxOcUSDeXHHDQV+CoRDKwyxdcAjNrljR9i9e241/hT6IuOO1mAKct40rdz5sCX4AC2bJsdaaRVpvK5TQnGpMf2HbwTVoi2XTFZIq9Ts0r0tJ/fv5aV74+CeTZOeIvPjY6,iv:5EogWN4PwKZcbxvPsbG8iqMvkUPzZL+D7D0xwGRDejY=,tag:apucpqGCzIHu9CJY+zPpog==,type:str]
+sops:
+    encrypted_regex: ((?i)(pass|secret($|[^N])|key|token|^data$|^stringData))
+    lastmodified: "2026-07-09T08:29:43Z"
+    mac: ENC[AES256_GCM,data:aKn7dlMDybiC0zAHz5AELiAw0osRSlRv08fTs/Z/rQcx+5F/acV9nicSgxUAhrBnDBCEsP+T9JKsReT0AcKxiZ1OMXK8/RvsthWImalYvRJ5yfMzQRFnu6Hsn31QgSMq7rTWKq7lgc/efdjF88pRYuPpmjMSy3vYFEn13rSC9uY=,iv:unfPq/jIt2IKiVIfHVNxHsnRhs5kAdtfCVvyxwRa9SE=,tag:eJNim8DeDIFk6hu2YJFXZQ==,type:str]
+    pgp:
+        - created_at: "2026-07-09T08:29:43Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA/M6fje6Wa1jAQ/+J/QsoD02ZYQCjYhlA6yVOP97eb1q5Yy1hlMu0+576OHs
+            KEiu1QFNV6bwDQdojbAjYC2DqxlM2DAOmbOmjAWlSw2WH3dg5v5FllOoL5iRhvJ1
+            U/xWQZezdQDNrr5BYfCTcEzx1GrM6oRbd75nx2P+1d4PEqWYi2Cx2StZbIlniXxj
+            7tBBB4GISAB9ptsjnEV1PTlWFjteXb/gLUjIbR7nMAlJKRVNDWge/8TkXiB+7C+4
+            mljwjXKtoaJ9Yy12BBZFionwrIkcuYl6wUksod5wHAzadqLLXm74o/yfCyrH0RNO
+            IOl2QOFDisWqW/djLiPhBlu4vYJHMQi8bURkHeVRzHkn8lRBWWFnKKKiO3ERu+H4
+            oU6LXsLuIz7Jx3BF1RaniH8IzpVQcpifzrE4auN6PVg495G7OPZoiFpiooR2aPeS
+            Y3klD73NDXrFQ/4Q6FmNQHB236oAwdp6ApRPwanokaQ+0eXqDR3mHDLgewjRpX0R
+            fZWygVeJQ5EsMPPMUcqftVmAPEcCeKC3jLcf/m38hTy1bwwlvx1DexO/gfmRsV/4
+            0XDNtZC4GvdsmB9/mkUWAz+5k47mNOP3JtoUF32CqcEb8JJuKzX4Bs9SastL2Fny
+            p/uKfg/SYeSeB0VCSs34Ow8jfVWBXnCY9p/N2VsTAXqFaUAdbHHorgLYtTEbeh3U
+            ZgEJAhAtDsduMdNiKailJr9SQNAAL7tEynDzmY3UhklYpDYLS7e1MmOMvyUZLrfW
+            gHpwd1dZ9sePnYBQe2kpOdz+8fhTnegENm7f5dClYgatiUOJWslJ8PLiHVKmzhJn
+            awr2MCNDnQ==
+            =IMYr
+            -----END PGP MESSAGE-----
+          fp: E1B9ED7DD949E306B657E2EB001154C49571BA66
+        - created_at: "2026-07-09T08:29:43Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA/wevS2MWPqcAQ//fi7Oj5kdAWYWkqk8lj/VbXyJyMTBxPPghyhI9IBy7ntb
+            ITkrnD/XreLb5g9ORqjrd9tTNcJ/wp12Ldg5gtUsX9VQMVQqbZuECvUiBqJmCcVD
+            45YwQrDGgGfG/KQlviOoPaCMxlhGHBKqbNW64nCaIx3CHg9W+r/XKmKz9pVekJdk
+            WKPdm9BiNDIkQsgGRUxSgoxp6dmAgNVF8BAwmMg+ure6G/Tt0PkV6ZPRCLvSdng9
+            tQRhqhKDs91F9OZV4oKv/jPSXtU5NqiSA13YLfiVza3cJ/4KZ4ObC68BDKiUe3tv
+            kB73XGpok+nYbCRD8hH8waIfy/1uR3Mn9+ORgOekQz2upsy11fistEuyjhntjsZL
+            4OEyBHIKP18YMLArOhSOCV5WY/5LoGqdPY62a71gg9K3vW7mkf5vpY/GL4qiNFSh
+            5iN4doL1Sh/L4VPh+uS8J+ZHZUMrdh7cEH/r348GrNROO09ikeWXYweLw8GU+f4g
+            QOIagbqknN1oYb3BS3IK+LciaQ0FZSOpq9UMIg+MKxHfje/5d2aXfTNksU0M5Lyf
+            n3ImLFJH2It6cHMyeVT0ZSow+z2nav+O7+PzW476dbeAwhEtgbs/9RH7jGcpfiBx
+            DUNS3tyAlZUe7789ENpR23M88aMfjxGLwPk+SwgQUv9inHUpZDwZCEjwP6ampVTU
+            ZgEJAhCmsytncFYEWimryf4wcVib5KA0rFZOWxADkg9LrFUjvcjahCleZEYH87JO
+            vS3HI9oO8Euloc4Fq51twgskAsdNj4LfMsqFXO8cG5k3zkpQ7eGq9Misl9AxzbfO
+            MrP77O+t0w==
+            =C3qn
+            -----END PGP MESSAGE-----
+          fp: DC28FBF0B880CCFC8CC1F5144447FB4C8CBA9DE0
+    version: 3.13.2


### PR DESCRIPTION
## Summary

Adds a second Home Assistant MCP server, this one for the **dad** instance (`home-assistant-dad`), mirroring the existing `home-assistant/mcp-server.yaml`.

## Changes
- `home-assistant-dad/mcp-server.yaml` — Deployment + Service + Ingress running `ghcr.io/homeassistant-ai/ha-mcp:7.11.0`, pointing at `http://home-assistant-dad:8123`, exposed at `mcp.homeassistant-dad.${BASE_DOMAIN}`.
- `home-assistant-dad/secret.sops.yaml` — sops-encrypted `home-assistant-dad-mcp` secret holding a long-lived access token for dad's HA (referenced by the deployment as `HOMEASSISTANT_TOKEN`).
- `home-assistant-dad/kustomization.yaml` — wires in the two new resources.

Everything is identical to the primary MCP server except the instance-specific bits: names, the `HOMEASSISTANT_URL`, the ingress host, and a dedicated token secret (the primary reuses the manually-managed `appdaemon` secret; this one uses its own sops-encrypted secret in git).

## Notes
- `kubectl kustomize cluster/apps/home-automation/home-assistant-dad/` builds clean.
- The token secret is encrypted to both PGP recipients from `.sops.yaml`, so Flux can decrypt it in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)