### PR TITLE
feat(pihole): forward .internal TLD to gateway

### DIFF
--- a/cluster/apps/network/pi-hole/helmrelease.yaml
+++ b/cluster/apps/network/pi-hole/helmrelease.yaml
@@ -59,9 +59,11 @@ spec:
       #   - ReadWriteOnce
       storageClass: longhorn
       size: 1Gi
-    # dnsmasq:
-    #   upstreamServers:
-    #     - 
+    dnsmasq:
+      upstreamServers:
+        # Forward the .internal private-use TLD to the gateway. dnsmasq
+        # otherwise treats .internal as local-only and never forwards it.
+        - server=/internal/192.168.100.1
     serviceWeb:
       # loadBalancerIP: 192.168.178.252
       # annotations:


### PR DESCRIPTION
## Problem
`estia.internal` (and any `*.internal` host) returns **NXDOMAIN** from Pi-hole, even though the gateway resolves it fine (`estia.internal → 192.168.58.139`).

## Root cause
dnsmasq treats the ICANN-reserved **`.internal`** private-use TLD as **local-only** and never forwards it upstream. Pi-hole answers `*.internal` itself in 0 ms → NXDOMAIN since it has no matching local record. (By contrast `.home` is forwarded normally, which is why `ha.home` works.)

## Fix
Add an explicit forwarder via the chart's `dnsmasq.upstreamServers`, which writes `server=/internal/192.168.100.1` verbatim into a dnsmasq `*.conf`. This overrides the local-only default and forwards all `*.internal` to `192.168.100.1` (the existing `DNS1` upstream / gateway).

## Verification after reconcile
```
dig estia.internal @<pihole-vip>   # expect NOERROR + A record, non-zero query time (forwarded)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)