### PR TITLE
Pin Traefik image to v3.7.10 (independent of chart version)

### DIFF
--- a/cluster/core/network-system/traefik/helmrelease-external.yaml
+++ b/cluster/core/network-system/traefik/helmrelease-external.yaml
@@ -18,9 +18,10 @@ spec:
       interval: 10m
 
   values:
-    # image:
-    #   name: ghcr.io/k8s-at-home/traefik
-    #   tag: 2.8.0
+    # Chart is pinned (k3s compatibility) but the Traefik image can be upgraded independently.
+    image:
+      repository: traefik
+      tag: "v3.7.10"
     deployment:
       kind: Deployment
       replicas: 1

--- a/cluster/core/network-system/traefik/helmrelease.yaml
+++ b/cluster/core/network-system/traefik/helmrelease.yaml
@@ -18,9 +18,10 @@ spec:
       interval: 10m
 
   values:
-    # image:
-    #   name: ghcr.io/k8s-at-home/traefik
-    #   tag: 2.8.0
+    # Chart is pinned (k3s compatibility) but the Traefik image can be upgraded independently.
+    image:
+      repository: traefik
+      tag: "v3.7.10"
     deployment:
       kind: Deployment
       replicas: 1


### PR DESCRIPTION
## What

The Traefik helm chart (`39.0.9`) is held back due to k3s compatibility, but the Traefik container **image** can be upgraded independently.

This overrides `image.tag` on both the internal (`traefik`) and external (`traefik-external`) HelmReleases:

- Chart 39.0.9 default appVersion: `v3.6.13`
- Pinned image: **`v3.7.10`** (latest v3)

Chart version is unchanged. Renovate's `helm-values` manager will track `image.tag` going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)