### PR TITLE
Add maintenance scale-down/up bundle script

### DIFF
--- a/scripts/maintenance-scale.sh
+++ b/scripts/maintenance-scale.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# maintenance-scale.sh — scale the heavy app bundle down/up during Longhorn or
+# cluster maintenance. Scale DOWN to relieve node/disk I/O while volumes rebuild;
+# scale UP to restore once everything is healthy again.
+#
+#   ./scripts/maintenance-scale.sh down     # scale bundle to 0 (records prior replicas)
+#   ./scripts/maintenance-scale.sh up        # restore (to recorded replicas, default 1)
+#   ./scripts/maintenance-scale.sh status    # show spec/ready replicas of the bundle
+#
+# Flux note: these are HelmRelease-managed, but helm-controller only resets
+# replicas on an actual chart/values upgrade, not on a periodic reconcile — so a
+# manual scale holds through a maintenance window. If you bump one of these
+# charts meanwhile it will pop back up; re-run `down` or suspend that HelmRelease.
+#
+# Uses the current kubectl context by default; override with LH_CONTEXT.
+set -euo pipefail
+ACTION=${1:-}
+CTX_ARG=(); [ -n "${LH_CONTEXT:-}" ] && CTX_ARG=(--context "$LH_CONTEXT")
+k(){ kubectl "${CTX_ARG[@]}" "$@"; }
+ANN="maintenance-prior-replicas"
+
+# namespace/deployment
+BUNDLE=(
+  home-automation/emhass
+  home-automation/esphome
+  home-automation/home-assistant-mcp
+  home-automation/home-assistant-dad-mcp
+  home-automation/signtools
+  media/flaresolverr
+  media/jackett
+  media/jellyfin
+  media/lidarr
+  media/ombi
+  media/prowlarr
+  media/radarr
+  media/sabnzbd
+  media/seerr
+  media/sonarr
+  media/tvheadend
+  network/uisp
+  web-util/hajimari
+)
+
+case "$ACTION" in
+  down)
+    for e in "${BUNDLE[@]}"; do ns=${e%%/*}; d=${e#*/}
+      cur=$(k -n "$ns" get deploy "$d" -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+      if [ -n "${cur:-}" ] && [ "$cur" != 0 ]; then
+        k -n "$ns" annotate deploy "$d" "$ANN=$cur" --overwrite >/dev/null
+      fi
+      k -n "$ns" scale deploy "$d" --replicas=0
+    done ;;
+  up)
+    for e in "${BUNDLE[@]}"; do ns=${e%%/*}; d=${e#*/}
+      want=$(k -n "$ns" get deploy "$d" -o jsonpath="{.metadata.annotations['$ANN']}" 2>/dev/null || true)
+      { [ -z "${want:-}" ] || [ "$want" = 0 ]; } && want=1
+      k -n "$ns" scale deploy "$d" --replicas="$want"
+    done ;;
+  status)
+    printf '%-40s %s\n' "DEPLOYMENT" "SPEC/READY"
+    for e in "${BUNDLE[@]}"; do ns=${e%%/*}; d=${e#*/}
+      printf '%-40s %s\n' "$e" "$(k -n "$ns" get deploy "$d" -o jsonpath='{.spec.replicas}/{.status.readyReplicas}' 2>/dev/null || echo 'missing')"
+    done ;;
+  *)
+    echo "usage: $(basename "$0") down|up|status" >&2; exit 1 ;;
+esac


### PR DESCRIPTION
Adds `scripts/maintenance-scale.sh` to scale the heavy app bundle down/up together during Longhorn or cluster maintenance.

## Why
When the cluster is struggling (e.g. Longhorn rebuilding a pile of degraded volumes), it helps to temporarily shed the I/O-heavy workloads, then bring them all back once things are healthy. Doing that deployment-by-deployment is tedious and error-prone.

## What it does
- `down` — records each deployment's current replica count in a `maintenance-prior-replicas` annotation, then scales it to 0.
- `up` — restores each to its recorded count (default 1 if none recorded).
- `status` — shows spec/ready replicas for the whole bundle.

## Bundle (18 deployments)
- **home-automation:** emhass, esphome, home-assistant-mcp, home-assistant-dad-mcp, signtools
- **media:** flaresolverr, jackett, jellyfin, lidarr, ombi, prowlarr, radarr, sabnzbd, seerr, sonarr, tvheadend
- **network:** uisp
- **web-util:** hajimari

## Usage
```
./scripts/maintenance-scale.sh down     # shed load
./scripts/maintenance-scale.sh status
./scripts/maintenance-scale.sh up       # restore
```
Uses the current kubectl context; override with `LH_CONTEXT`.

**Flux note:** these are HelmRelease-managed, but helm-controller only resets replicas on an actual chart/values upgrade, not on a periodic reconcile — so a manual scale holds through a maintenance window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)