### PR TITLE
pod-gateway: auto-reload webhook on cert rotation

### DIFF
--- a/cluster/apps/network/pod-vpn-gateway/helmrelease.yaml
+++ b/cluster/apps/network/pod-vpn-gateway/helmrelease.yaml
@@ -18,6 +18,24 @@ spec:
         name: k8s-at-home
         namespace: flux-system
       interval: 10m
+  # The gateway-admission-controller reads its serving cert only at startup and
+  # does not watch the secret, so when cert-manager rotates the leaf the running
+  # webhook keeps serving the old cert until it expires (breaks all vpn-namespace
+  # pod creation). Annotate the webhook Deployment so Stakater Reloader restarts
+  # it whenever the cert secret changes.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: vpn-gateway-pod-gateway-webhook
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: vpn-gateway-pod-gateway-webhook
+                annotations:
+                  reloader.stakater.com/auto: "true"
   # See https://github.com/k8s-at-home/charts/blob/master/charts/pod-gateway/values.yaml
   values:
     image:


### PR DESCRIPTION
## Problem
The `vpn-gateway` pod-gateway **mutating webhook** (`gateway-admission-controller`) reads its TLS serving cert **only at startup** and does not watch the secret. cert-manager rotates the webhook leaf every ~year, but the long-running webhook pod keeps serving the **old** cert until it expires — at which point the fail-closed webhook rejects **all pod creation in the `vpn` namespace** (transmission, rtorrent, …) with:

```
x509: certificate has expired ... failed calling webhook "vpn-gateway-pod-gateway..."/setgateway
```

This just bit us: cert-manager renewed the leaf in Apr 2026 (valid → Apr 2027), but the webhook kept serving the original Aug-2025 leaf until it expired 2026-08-05. A pod restart cleared it, but it will recur at every rotation.

## Fix
Stakater Reloader is already deployed (`util-system/reloader-reloader`). This adds a HelmRelease `postRenderers` kustomize patch annotating the webhook Deployment:

```yaml
reloader.stakater.com/auto: "true"
```

so Reloader restarts the webhook whenever `vpn-gateway-pod-gateway-webhook-tls` changes — the new cert is picked up immediately and this stops recurring. Done via postRenderer because the archived pod-gateway chart (5.3.0) doesn't expose webhook annotations.

No cert/CA change needed — both are valid (CA → 2030, leaf → Apr 2027); this only fixes the pod not reloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)