### PR TITLE
evcc-optimizer: 1 worker; raise cpu limit to 1

### DIFF
--- a/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
+++ b/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
@@ -28,6 +28,15 @@ spec:
               pullPolicy: Always
             env:
               TZ: "Australia/Sydney"
+              # The image bakes in `--workers 4` via GUNICORN_CMD_ARGS, which overrides
+              # WEB_CONCURRENCY. Each worker loads its own solver, so 4 workers is the
+              # bulk of the memory. evcc only calls the optimizer periodically, so a
+              # single worker is enough; override to 1 (cuts RSS to ~1/4) and pin it
+              # against future `latest` builds; keep the image's other gunicorn flags.
+              GUNICORN_CMD_ARGS: >-
+                --workers 1 --max-requests 32
+                --config python:optimizer.gunicorn_conf
+                --access-logfile - --access-logformat '%(m)s %(U)s %(s)s %(D)s'
             probes:
               liveness:
                 enabled: true
@@ -54,7 +63,8 @@ spec:
                 cpu: 10m
                 memory: 64Mi
               limits:
-                cpu: 200m
+                # raised from 200m so the single-threaded ~10s solve isn't throttled
+                cpu: "1"
                 memory: 256Mi
     service:
       app:


### PR DESCRIPTION
## Why
The optimizer was returning bad results under load. Root cause: the `evcc/optimizer:latest` image bakes in **`--workers 4`** via `GUNICORN_CMD_ARGS`. Each gunicorn worker loads its own solver, so 4 workers dominate memory — steady **~212Mi** against the **256Mi** limit.

Under concurrent/heavy solves the container RSS transiently exceeds 256Mi and the kernel OOM-kills a **gunicorn worker** (not PID 1) — so k8s shows **no restart and no OOM event**, but the in-flight `/optimize/charge-schedule` request that worker was serving dies/returns partial → **"funny results."** A recent `latest` build likely raised the worker count, which is why it started now.

Note: `WEB_CONCURRENCY` is **not** honored — `--workers 4` on the (env-injected) gunicorn command line overrides it. The only way to change it is `GUNICORN_CMD_ARGS`.

## Change
- **`GUNICORN_CMD_ARGS` → `--workers 1`** — evcc only calls the optimizer periodically, so one worker suffices. Cuts RSS to ~1/4 (one solver in memory) and pins the count against future `latest` rebuilds; keeps the image's other flags (`--max-requests 32`, config module, access logging).
- **Raise cpu limit `200m → 1`** so the single-threaded ~10s solve (`OPTIMIZER_TIME_LIMIT=10`, `OPTIMIZER_NUM_THREADS=1`) isn't throttled.
- **Memory unchanged** (`64Mi` req / `256Mi` limit) — with one worker the earlier 400Mi bump isn't needed; steady RSS should sit ~55–70Mi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)