### PR TITLE
Fix evcc-optimizer image digest (multi-arch, not amd64-only)

### DIFF
--- a/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
+++ b/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
@@ -30,9 +30,11 @@ spec:
               # evcc/optimizer publishes only `latest` + git-SHA tags (no semver), so
               # pin `latest` by digest for reproducibility and let renovate raise a PR
               # when upstream pushes a new build instead of it changing silently.
+              # NB: this MUST be the multi-arch manifest-list digest (amd64+arm64) — a
+              # per-arch sub-digest CrashLoops when the pod lands on a Pi (arm64) node.
               repository: evcc/optimizer
               # renovate: datasource=docker depName=evcc/optimizer versioning=docker
-              tag: latest@sha256:97addf863797843e5078542d436e806ea2cde14fffbd2bdd30036e9bcfcf2080
+              tag: latest@sha256:d90be3578e703e07697afd25a1eb914fa2fb90d38c63f24bc628525cfdbc78ee
               pullPolicy: IfNotPresent
             env:
               TZ: "Australia/Sydney"


### PR DESCRIPTION
## Hotfix for #2856
#2856 pinned the **amd64-only sub-digest** (`sha256:97addf86…`) instead of the **multi-arch manifest-list digest**. Result: the optimizer **CrashLoops on arm64 (Pi) nodes** — it landed on `pi3` and couldn't run.

## Fix
Repin to the manifest-list digest **`sha256:d90be3578e…`**, which containerd resolves to the node's own arch. Confirmed `evcc/optimizer:latest` publishes both `amd64` and `arm64`.

No other change — renovate annotation, `IfNotPresent`, and `RollingUpdate` from #2856 stay as-is. (The RollingUpdate strategy is why this wasn't a hard outage: the old working pod kept serving while the amd64-pinned pod stayed non-Ready.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)