### PR TITLE
evcc-optimizer: raise solver time limit to 30s

### DIFF
--- a/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
+++ b/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
@@ -38,6 +38,10 @@ spec:
               pullPolicy: IfNotPresent
             env:
               TZ: "Australia/Sydney"
+              # Solver time budget per solve (image default 10s). evcc only runs the
+              # optimizer once every ~5 min, so latency is a non-issue — give it more
+              # time to reach `optimal` instead of stopping at `feasible`.
+              OPTIMIZER_TIME_LIMIT: "30"
               # The image bakes in `--workers 4` via GUNICORN_CMD_ARGS, which overrides
               # WEB_CONCURRENCY. Each worker loads its own solver, so 4 workers is the
               # bulk of the memory. evcc only calls the optimizer periodically, so a


### PR DESCRIPTION
## Why
The optimizer often reports solver state **`feasible`** (a valid schedule, but not *proven* optimal) rather than **`optimal`** — because it hits the image's default **`OPTIMIZER_TIME_LIMIT=10`s** on the slower/CPU-constrained node before proving optimality.

evcc only runs the optimizer **~once every 5 minutes**, so a longer solve costs nothing in practice.

## Change
Set **`OPTIMIZER_TIME_LIMIT: "30"`** (10s → 30s) so the single-threaded solve has room to reach `optimal` more often.

Pairs with #2855 (cpu limit → 1, which also helps the solve do more work in the budget). Can go higher later if `feasible` still shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)