### PR TITLE
evcc-optimizer: make gunicorn override build-agnostic (unbreak digest bumps)

### DIFF
--- a/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
+++ b/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
@@ -43,13 +43,16 @@ spec:
               # time to reach `optimal` instead of stopping at `feasible`.
               OPTIMIZER_TIME_LIMIT: "30"
               # The image bakes in `--workers 4` via GUNICORN_CMD_ARGS, which overrides
-              # WEB_CONCURRENCY. Each worker loads its own solver, so 4 workers is the
-              # bulk of the memory. evcc only calls the optimizer periodically, so a
-              # single worker is enough; override to 1 (cuts RSS to ~1/4) and pin it
-              # against future `latest` builds; keep the image's other gunicorn flags.
+              # WEB_CONCURRENCY, so overriding the whole arg string is the only way to
+              # drop to 1 worker (evcc calls the optimizer only periodically; cuts RSS
+              # to ~1/4). Deliberately do NOT pass `--config python:optimizer.gunicorn_conf`
+              # here: some published `latest` builds ship without that module and forcing
+              # it crashes with "No module named 'optimizer.gunicorn_conf'". It is only an
+              # optional reaper for solvers left by a *killed* worker — negligible with a
+              # single worker and comfortable memory. Keeping the args build-agnostic means
+              # renovate digest bumps won't break us.
               GUNICORN_CMD_ARGS: >-
                 --workers 1 --max-requests 32
-                --config python:optimizer.gunicorn_conf
                 --access-logfile - --access-logformat '%(m)s %(U)s %(s)s %(D)s'
             probes:
               liveness:


### PR DESCRIPTION
## What happened
The renovate digest bump (#2859 → `5e52124`) crashed the optimizer with:
```
No module named 'optimizer.gunicorn_conf'
```
It was **reverted** already (master is back on the known-good `d90be357`, pod healthy), but it will **recur on the next digest bump** unless we fix the root cause.

## Root cause
Our `GUNICORN_CMD_ARGS` override (from #2855, needed to force `--workers 1` since the image bakes `--workers 4` and `WEB_CONCURRENCY` is ignored) copied the old image's `--config python:optimizer.gunicorn_conf`. Some published `latest` builds ship **without** that module — even though the current upstream Dockerfile still references it (the published `latest` is skewed from `main`). Forcing `--config` on such a build → crash.

Verified directly:
- `d90be357` (current): `optimizer.gunicorn_conf` present → works.
- `5e52124` (bumped): module absent, and the image's *own* baked args are `--workers 4 --max-requests 32` (no `--config`) → the image runs fine on its own; only our forced `--config` breaks it.

## Fix
Drop `--config python:optimizer.gunicorn_conf` from our override. It's only an optional reaper for solvers orphaned by a **killed** worker — negligible with `--workers 1` and our comfortable memory. The override is now build-agnostic (`--workers 1 --max-requests 32` + access logging), so renovate digest bumps won't break us. Digest itself unchanged (stays on the healthy `d90be357`); the next bump can merge safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)