### PR TITLE
evcc-optimizer: freeze renovate digest updates (upstream tags unreliable)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -135,5 +135,23 @@
         'ghcr.io/linuxserver/jackett',
       ],
     },
+    {
+      // evcc/optimizer only publishes `latest` + git-SHA tags (no semver), and
+      // upstream re-points `latest` at inconsistent branch builds (e.g. an old
+      // root-user build with no gunicorn_conf). SHA tags are unorderable so
+      // renovate can't follow them, and minimumReleaseAge can't help (bad builds
+      // are old re-pushes). Freeze digest auto-updates; bump the pinned digest
+      // manually after vetting the image (see the helmrelease comment).
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'evcc/optimizer',
+      ],
+      matchUpdateTypes: [
+        'digest',
+      ],
+      enabled: false,
+    },
   ],
 }

--- a/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
+++ b/cluster/apps/home-automation/evcc/evcc-optimizer-helmrelease.yaml
@@ -27,13 +27,16 @@ spec:
         containers:
           app:
             image:
-              # evcc/optimizer publishes only `latest` + git-SHA tags (no semver), so
-              # pin `latest` by digest for reproducibility and let renovate raise a PR
-              # when upstream pushes a new build instead of it changing silently.
-              # NB: this MUST be the multi-arch manifest-list digest (amd64+arm64) — a
-              # per-arch sub-digest CrashLoops when the pod lands on a Pi (arm64) node.
+              # MANUALLY pinned digest — renovate digest auto-updates are disabled for
+              # this image in .github/renovate.json5. Upstream only ships `latest` +
+              # unorderable git-SHA tags and re-points `latest` at inconsistent branch
+              # builds, so auto-tracking is unsafe. To bump: pick a new digest, VET it
+              #   docker run --rm --entrypoint sh evcc/optimizer@sha256:<d> -c \
+              #     'id; /app/.venv/bin/python -c "import optimizer.gunicorn_conf"'
+              # (want user `app`, no import error), then update the digest below.
+              # NB: use the multi-arch manifest-list digest (amd64+arm64) — a per-arch
+              # sub-digest CrashLoops when the pod lands on a Pi (arm64) node.
               repository: evcc/optimizer
-              # renovate: datasource=docker depName=evcc/optimizer versioning=docker
               tag: latest@sha256:d90be3578e703e07697afd25a1eb914fa2fb90d38c63f24bc628525cfdbc78ee
               pullPolicy: IfNotPresent
             env:


### PR DESCRIPTION
## Why
Chasing `evcc/optimizer:latest` has been a mess. Root cause (all verified against the live images):
- Upstream publishes only `latest` + **git-SHA tags with no semver** — renovate can't order SHA tags, so it can only follow `latest`'s digest.
- Upstream **re-points `latest` at inconsistent branch builds**. We got bitten by `5e52124`, which is an **old, root-user build with no `gunicorn_conf` module** (its image SHA tags don't match any `main` commit — they're feature-branch builds, e.g. PR #136 merged into `perf/two-stage-solve`).
- `minimumReleaseAge` can't save us either — the bad builds are *old* re-pushes, so they already look "stable."

Renovate isn't broken; it faithfully followed a tag that upstream mismanages. But auto-tracking this image is not safe.

## Change
- **Disable renovate digest auto-updates for `evcc/optimizer`** (packageRule in `.github/renovate.json5`).
- **Manage the pinned digest manually**, with a vetting one-liner documented at the image:
  ```
  docker run --rm --entrypoint sh evcc/optimizer@sha256:<digest> -c \
    'id; /app/.venv/bin/python -c "import optimizer.gunicorn_conf"'
  ```
  (want user `app`, no import error → a real `main` build).
- Digest **unchanged** (stays on the healthy `d90be357` that's running now).

Backstop: #2864 already makes a regressed build non-fatal (our gunicorn override no longer forces the `--config` module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)